### PR TITLE
Fix: FaceTime Link Creation

### DIFF
--- a/Momiji/Function/groupAdmins.swift
+++ b/Momiji/Function/groupAdmins.swift
@@ -25,7 +25,9 @@ func handleGroupAdmins(appState: AppState, event: Event, relayUrl: String) {
     )
     
     DispatchQueue.main.async {
-        appState.allGroupAdmin.append(admin)
+        if !appState.allGroupAdmin.contains(where: { $0.groupId == admin.groupId }){
+            appState.allGroupAdmin.append(admin)
+        }
     
         if publicKey == appState.selectedOwnerAccount?.publicKey {
             // Update isAdmin of allChatGroup

--- a/Momiji/Function/groupMetadata.swift
+++ b/Momiji/Function/groupMetadata.swift
@@ -11,7 +11,6 @@ func handleGroupMetadata(appState: AppState, event: Event) {
     let name = tags.first(where: { $0.id == "name" })?.otherInformation.first
     let about = tags.first(where: { $0.id == "about" })?.otherInformation.first
     let picture = tags.first(where: { $0.id == "picture" })?.otherInformation.first
-    let link = tags.first(where: { $0.id == "r" })?.otherInformation.first
     
     
     let dateFormatter = DateFormatter()
@@ -29,11 +28,11 @@ func handleGroupMetadata(appState: AppState, event: Event) {
         isPublic: isPublic,
         isOpen: isOpen,
         isMember: false,
-        isAdmin: false,
-        link: link
+        isAdmin: appState.allChatGroup.contains(where: { $0.id == groupId })
     )
     
     DispatchQueue.main.async {
+        appState.allChatGroup.removeAll(where: { $0.id == groupId })
         appState.allChatGroup.append(metadata)
         
         // Extract the top 20 groups from the newest group metadata

--- a/Momiji/Struct/ChatGroupMetadata.swift
+++ b/Momiji/Struct/ChatGroupMetadata.swift
@@ -9,5 +9,4 @@ struct ChatGroupMetadata: Identifiable, Encodable, Hashable {
     var isOpen: Bool
     var isMember: Bool
     var isAdmin: Bool
-    var link: String?
 }

--- a/Momiji/Struct/UserMetadata.swift
+++ b/Momiji/Struct/UserMetadata.swift
@@ -13,4 +13,5 @@ struct UserMetadata: Encodable, Hashable {
     var bot: Bool?
     var lud16: String?
     var createdAt: Date
+    var facetime: String?
 }

--- a/Momiji/Views/Component/Setting/MetadataRelayView.swift
+++ b/Momiji/Views/Component/Setting/MetadataRelayView.swift
@@ -13,7 +13,7 @@ struct MetadataRelayView: View {
         relays.filter { !$0.supportsNip29 }
     }
     
-    @State private var suggestedRelays: [String] = ["wss://relay.damus.io", "wss://nostr.land", "wss://yabu.me", "ws://217.142.246.199:2929"]
+    @State private var suggestedRelays: [String] = ["wss://relay.damus.io", "wss://nostr.land", "wss://yabu.me"]
     var filteredSuggestedRelays: [String] {
         let relayUrls = relays.map { $0.url }
         return suggestedRelays.filter { !relayUrls.contains($0) }

--- a/Momiji/Views/Component/Setting/Nip29RelayView.swift
+++ b/Momiji/Views/Component/Setting/Nip29RelayView.swift
@@ -13,7 +13,7 @@ struct Nip29RelayView: View {
         return relays.filter({ $0.supportsNip29 })
     }
     
-    @State var suggestedRelays: [String] = ["wss://groups.0xchat.com", "wss://relay.groups.nip29.com", "ws://217.142.246.199:2929"]
+    @State var suggestedRelays: [String] = ["wss://groups.0xchat.com", "wss://relay.groups.nip29.com", "wss://groups.yugoatobe.com"]
     var filteredSuggestedRelays: [String] {
         return suggestedRelays.filter { s in !chatRelays.contains { r in r.url == s }}
     }

--- a/Momiji/Views/Window/CreateSessionView.swift
+++ b/Momiji/Views/Window/CreateSessionView.swift
@@ -62,7 +62,7 @@ struct CreateSessionView: View {
                                 .foregroundColor(.white)
                         }
                         
-                        Text("New Playlist")
+                        Text("New Group")
                             .padding(.leading, 8)
                         Spacer()
                     }

--- a/Momiji/Views/Window/EditSessionLink.swift
+++ b/Momiji/Views/Window/EditSessionLink.swift
@@ -49,8 +49,10 @@ struct SessionLinkView: View {
                             return
                         }
                         
-                        // FaceTimeリンクをrタグに設定する
-                        await appState.editGroupMetadata(ownerAccount: account, group: group, name: groupName, about: groupDescription, link: groupLink)
+                        // Changing group metadata
+                        await appState.editGroupMetadata(ownerAccount: account, group: group, name: groupName, about: groupDescription)
+                        // Set up a facetime link
+                        await appState.editFacetimeLink(link: groupLink)
                         
                     }
                 }) {
@@ -152,6 +154,7 @@ struct SessionLinkView: View {
                 groupImage = groupMetadata.picture ?? ""
                 groupName = groupMetadata.name ?? ""
                 groupDescription = groupMetadata.about ?? ""
+                groupLink = fetchAdminUserMetadata().first?.facetime ?? ""
             }
         }
         // Relay からOKが返ってきたら、シートを閉じる
@@ -164,5 +167,15 @@ struct SessionLinkView: View {
 
         Spacer()
         
+    }
+    
+    private func fetchAdminUserMetadata() -> [UserMetadata] {
+        let adminPublicKeys = appState.allGroupAdmin
+            .filter { $0.groupId == appState.selectedGroup?.id }
+            .map { $0.publicKey }
+        let adminMetadatas = appState.allUserMetadata.filter { user in
+            adminPublicKeys.contains(user.publicKey)
+        }
+        return adminMetadatas
     }
 }

--- a/Momiji/Views/Window/SessionDetailView.swift
+++ b/Momiji/Views/Window/SessionDetailView.swift
@@ -66,7 +66,7 @@ struct SessionDetailView: View {
                 
                 HStack(spacing: 20) {
                     // MARK: すでにShareplayセッションが確立されている状態
-                    if group.isMember && groupActivityManager.isSharePlaying {
+                    if groupActivityManager.isSharePlaying {
                         Button(action: {
                             Task {
                                 // SharePlayセッションを終了する
@@ -83,11 +83,12 @@ struct SessionDetailView: View {
                                 .padding()
                         }.tint(.red)
                     // MARK: Shareplayセッションを確立していない場合
-                    } else if !group.isMember && !groupActivityManager.isSharePlaying  {
+                    } else {
                         Button(action: {
                             Task{
-                                let newFaceTimeLink = "https://facetime.apple.com/join#v=1&p=t9aoR9YKEe+d4VrAeXsElw&k=moGs7GGvqaK0GbDNOuyS87l4NQJolINBqXuvV_Ft_Kw"
-                                if let url = URL(string: newFaceTimeLink) {
+                                // MARK: Adminが複数存在するという状態を省く必要がある
+                                let faceTimeLink = fetchAdminUserMetadata().first?.facetime ?? ""
+                                if let url = URL(string: faceTimeLink) {
                                     await UIApplication.shared.open(url)
                                 }
                             }
@@ -96,7 +97,7 @@ struct SessionDetailView: View {
                                 .frame(maxWidth: .infinity)
                                 .padding()
                         }
-                        .disabled(groupStateObserver.isEligibleForGroupSession)
+                        .disabled(groupStateObserver.isEligibleForGroupSession || fetchAdminUserMetadata().first?.facetime == nil)
                         .tint(.green)
                         Button(action: {
                             Task {
@@ -231,6 +232,14 @@ struct SessionDetailView: View {
             .padding(.vertical)
             .padding(.trailing, 100)
             .frame(maxWidth: 500)
+        }
+        .onAppear {
+            let faceTimeLink = fetchAdminUserMetadata().first?.facetime
+            if faceTimeLink == nil || faceTimeLink?.isEmpty == true {
+                sharePlayStatus = "Facetimeリンクが設定されていません。"
+            } else {
+                sharePlayStatus = faceTimeLink!
+            }
         }
     }
                          


### PR DESCRIPTION
## What you did with this PR
FaceTimeリンクを設定できるようにしました。
また、FaceTimeリンクが存在する場合のみ、FaceTimeを始められるようにした。

## Background and purpose
現状ベタ書きでFaceTimeリンクを設定していた。それを編集できるようにしたかった。

## What you want reviewers to check out
- [x] Add spaceからFaceTimeリンクを編集できる。
- [x] Facetimeリンクが存在する場合、FaceTimeボタンがSessionDetailViewから押すことができる

## Screenshots (for screen implementation)
なし

## Memo
現状、FaceTimeのリンクの情報をグループのAdminのユーザーのtagの中にfacetimeタグを作成して運用している。
しかし、本質的に考えるとグループのメタデータに存在するべきなので今後修正する必要がある。
